### PR TITLE
(fix): Updated rootDir in root tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "rootDir": ".",                                      /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -109,5 +109,9 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*",
+    "tests/loadTests/src/**/*"
+  ]
 }


### PR DESCRIPTION
To fix the problem below, I had to bring both tsconfigs under the same rootDir.
```
File '/Task-Manager-API/tests/loadTests/src/index.ts' is not under 'rootDir' '/Task-Manager-API/src'. 'rootDir' is expected to contain all source files.
The file is in the program because:
Matched by default include pattern '**/*'
```